### PR TITLE
Support USER/SYSTEM mode on SOSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # apex-parser - Changelog
 
-## 4.0.0 - 2023-03-28
+## 4.1.0 - 2024-05-12
+
+- Allow WITH USER_MODE or SYSTEM_MODE on SOSL queries
+
+## 4.0.0 - 2024-03-28
 
 - Correct trigger body parsing to allow member declarations
 - Add support for TYPEOF in SOQL subqueries

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Maven
     <dependency>
         <groupId>io.github.apex-dev-tools</groupId>
         <artifactId>apex-parser</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </dependency>
 
 NPM
 
-    "@apexdevtools/apex-parser": "^4.0.0"
+    "@apexdevtools/apex-parser": "^4.1.0"
 
 ## Building
 

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -826,15 +826,21 @@ soslLiteralAlt
 soslClauses
     : (IN searchGroup)?
       (RETURNING fieldSpecList)?
-      (WITH DIVISION ASSIGN StringLiteral)?
-      (WITH DATA CATEGORY filteringExpression)?
-      (WITH SNIPPET (LPAREN TARGET_LENGTH ASSIGN IntegerLiteral RPAREN)? )?
-      (WITH NETWORK IN LPAREN networkList RPAREN)?
-      (WITH NETWORK ASSIGN StringLiteral)?
-      (WITH PRICEBOOKID ASSIGN StringLiteral)?
-      (WITH METADATA ASSIGN StringLiteral)?
+      soslWithClause*
       limitClause?
       (UPDATE updateList)?
+    ;
+
+soslWithClause
+    : WITH DIVISION ASSIGN StringLiteral
+    | WITH DATA CATEGORY filteringExpression
+    | WITH SNIPPET (LPAREN TARGET_LENGTH ASSIGN IntegerLiteral RPAREN)?
+    | WITH NETWORK IN LPAREN networkList RPAREN
+    | WITH NETWORK ASSIGN StringLiteral
+    | WITH PRICEBOOKID ASSIGN StringLiteral
+    | WITH METADATA ASSIGN StringLiteral
+    | WITH USER_MODE
+    | WITH SYSTEM_MODE
     ;
 
 searchGroup

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>apex-parser</artifactId>
-  <version>4.0.0</version>
+  <version>4.1.0</version>
   <packaging>jar</packaging>
 
   <name>apex-parser</name>
@@ -59,9 +60,9 @@
 
   <dependencies>
     <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-runtime</artifactId>
-        <version>4.9.1</version>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr4-runtime</artifactId>
+      <version>4.9.1</version>
     </dependency>
 
     <dependency>

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SOSLParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SOSLParserTest.java
@@ -60,4 +60,20 @@ public class SOSLParserTest {
         assertNotNull(context);
         assertEquals(1, parserAndCounter.getValue().getNumErrors());
     }
+
+    @Test
+    void testWithUserModeQuery() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'something' RETURNING Account WITH USER_MODE WITH METADATA='Labels']");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testWithSystemModeQuery() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'something' RETURNING Account WITH METADATA='Labels' WITH SYSTEM_MODE]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
 }

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/apex-parser",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "antlr4ts": "0.5.0-alpha.4",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "Apex Dev Tools Team <apexdevtools@gmail.com> (https://github.com/apex-dev-tools)",
   "bugs": "https://github.com/apex-dev-tools/apex-parser/issues",
   "description": "Javascript parser for Salesforce Apex Language",

--- a/npm/src/__tests__/SOSLParserTest.ts
+++ b/npm/src/__tests__/SOSLParserTest.ts
@@ -61,3 +61,21 @@ test('testQuotesFailOnAltFormat', () => {
     expect(context).toBeInstanceOf(SoslLiteralAltContext)
     expect(errorCounter.getNumErrors()).toEqual(1)
 })
+
+test('testWithUserModeQuery', () => {
+    const [parser, errorCounter] = createParser("[Find 'something' RETURNING Account WITH USER_MODE WITH METADATA='Labels']")
+
+    const context = parser.soslLiteralAlt()
+
+    expect(context).toBeInstanceOf(SoslLiteralAltContext)
+    expect(errorCounter.getNumErrors()).toEqual(1)
+})
+
+test('testWithSystemModeQuery', () => {
+    const [parser, errorCounter] = createParser("[Find 'something' RETURNING Account WITH METADATA='Labels' WITH SYSTEM_MODE]")
+
+    const context = parser.soslLiteralAlt()
+
+    expect(context).toBeInstanceOf(SoslLiteralAltContext)
+    expect(errorCounter.getNumErrors()).toEqual(1)
+})


### PR DESCRIPTION
This adds SOSL USER_MODE & SYSTEM_MODE support to SOSL. Previously the WITH clauses where required to be in a fixed order which the doc leads you to believe is needed. When testing it was clear you can order them any way, but they must appear before a LIMIT or UPDATE clause if they are used so I have made WITH clause ordering flexible. 