### PR TITLE
Add support for >2 nested SOQL queries in SELECTS

### DIFF
--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -602,6 +602,7 @@ subFieldList
 subFieldEntry
     : fieldName soqlId?
     | soqlFunction soqlId?
+    | LPAREN subQuery RPAREN soqlId?
     | typeOf
     ;
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "antlr4ts": "npm run antlr-build && npm run antlr-patch",
-    "antlr-build": "(cd antlr; antlr4ts -visitor -o ../src ApexLexer.g4 ApexParser.g4)",
+    "antlr-build": "cd antlr && antlr4ts -visitor -o ../src ApexLexer.g4 ApexParser.g4",
     "antlr-patch": "node patch",
     "build": "npm run clean && npm run antlr4ts && cp ../*.md . && tsc",
     "check": "node -e 'require(\"./lib/index.js\").check()'",

--- a/npm/src/__tests__/SOQLParserTest.ts
+++ b/npm/src/__tests__/SOQLParserTest.ts
@@ -107,3 +107,14 @@ test("testGeoLocationFunction", () => {
   expect(context).toBeInstanceOf(QueryContext);
   expect(errorCounter.getNumErrors()).toEqual(0);
 });
+
+test("SubQuery", () => {
+  const [parser, errorCounter] = createParser(
+    "SELECT Name, (SELECT Id, (SELECT Id, (SELECT Id, (SELECT Id FROM Child4 ) FROM Child3 ) FROM Child2 ) FROM Child1) FROM Parent"
+  );
+
+  const context = parser.query();
+
+  expect(context).toBeInstanceOf(QueryContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run build-npm && npm run build-jvm",
     "build-npm": "npm run init-npm && cd npm && npm run build && npm run test && cd ..",
     "build-jvm": "npm run init-jvm && cd jvm && mvn package && cd ..",
-    "init-npm": "cp antlr/* npm/antlr && (cd npm; npm ci)",
+    "init-npm": "cp antlr/* npm/antlr && cd npm && npm ci",
     "init-jvm": "cp antlr/* jvm/src/main/antlr4/io/github/apexdevtools/apexparser"
   },
   "files": [],


### PR DESCRIPTION
Allows higher depth of SOQL query child nesting. Aiming to fix issue raised https://github.com/apex-dev-tools/apex-parser/issues/46

```SQL
SELECT Name, 
  (SELECT Id, 
    (SELECT Id, 
      (SELECT Id, 
        (SELECT Id FROM Child4 ) 
      FROM Child3 ) 
    FROM Child2 ) 
  FROM Child1) 
FROM Parent
```


I had to update some of the build commands to have it correctly run. I'm not completely sure if the JAVA version is functioning