### PR TITLE
Support toLabel in SOSL queries

### DIFF
--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -864,6 +864,7 @@ fieldSpec
 
 fieldList
     : soslId (COMMA fieldList)*
+    | TOLABEL LPAREN soslId RPAREN
     ;
 
 updateList

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SOSLParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SOSLParserTest.java
@@ -76,4 +76,12 @@ public class SOSLParserTest {
         assertNotNull(context);
         assertEquals(0, parserAndCounter.getValue().getNumErrors());
     }
+
+    @Test
+    void testToLabel() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[FIND :searchTerm IN ALL FIELDS RETURNING Account(Id, toLabel(Name)) LIMIT 10]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
 }

--- a/npm/src/__tests__/SOSLParserTest.ts
+++ b/npm/src/__tests__/SOSLParserTest.ts
@@ -65,17 +65,26 @@ test('testQuotesFailOnAltFormat', () => {
 test('testWithUserModeQuery', () => {
     const [parser, errorCounter] = createParser("[Find 'something' RETURNING Account WITH USER_MODE WITH METADATA='Labels']")
 
-    const context = parser.soslLiteralAlt()
+    const context = parser.soslLiteral()
 
-    expect(context).toBeInstanceOf(SoslLiteralAltContext)
-    expect(errorCounter.getNumErrors()).toEqual(1)
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
 })
 
 test('testWithSystemModeQuery', () => {
     const [parser, errorCounter] = createParser("[Find 'something' RETURNING Account WITH METADATA='Labels' WITH SYSTEM_MODE]")
 
-    const context = parser.soslLiteralAlt()
+    const context = parser.soslLiteral()
 
-    expect(context).toBeInstanceOf(SoslLiteralAltContext)
-    expect(errorCounter.getNumErrors()).toEqual(1)
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})
+
+test('testToLabel', () => {
+    const [parser, errorCounter] = createParser("[FIND :searchTerm IN ALL FIELDS RETURNING Account(Id, toLabel(Name)) LIMIT 10]")
+
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
 })


### PR DESCRIPTION
Current `toLabel` causes a parser error:

```
public with sharing class ParseErrorTest {
    public Object doSoslSearch() {

        List<List<SObject>> searchResults = [
                FIND :searchTerm
                IN ALL FIELDS
                RETURNING
                        Account(Id, toLabel(Name))
                LIMIT 10
        ];
        
        return null;        
    }
}
```

Error:

```
Syntax error at 9:43: mismatched input '(' expecting {'using', 'where', 'order', 'limit', 'offset', ')'}
Syntax error at 9:49: mismatched input ')' expecting {'instanceof', ')', '[', '.', '=', '>', '<', '?.', '?', '==', '===', '!=', '<>', '!==', '&&', '||', '??', '++', '--', '+', '-', '*', '/', '&', '|', '^', '+=', '-=', '*=', '/=', '&=', '|=', '^=', '<<=', '>>=', '>>>='}
Syntax error at 11:8: extraneous input ']' expecting ';'
```

sf doc: https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_sosl_tolabel.htm

Original reported at: https://github.com/pmd/pmd/issues/5163