### PR TITLE
Support convertCurrency() function in SOQL and SOSL

### DIFF
--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -171,6 +171,7 @@ STANDARD        : 'standard';
 DISTANCE        : 'distance';
 GEOLOCATION     : 'geolocation';
 GROUPING        : 'grouping';
+CONVERT_CURRENCY : 'convertcurrency'; // used in both SOQL and SOSL
 
 // SOQL Date functions
 CALENDAR_MONTH      : 'calendar_month';

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -620,7 +620,7 @@ soqlFunction
     | MAX LPAREN fieldName RPAREN
     | SUM LPAREN fieldName RPAREN
     | TOLABEL LPAREN fieldName RPAREN
-    | FORMAT LPAREN fieldName RPAREN
+    | FORMAT LPAREN ( fieldName | soqlFunction ) RPAREN
     | CALENDAR_MONTH LPAREN dateFieldName RPAREN
     | CALENDAR_QUARTER LPAREN dateFieldName RPAREN
     | CALENDAR_YEAR LPAREN dateFieldName RPAREN
@@ -637,6 +637,7 @@ soqlFunction
     | FIELDS LPAREN soqlFieldsParameter RPAREN
     | DISTANCE LPAREN locationValue COMMA locationValue COMMA StringLiteral RPAREN
     | GROUPING LPAREN fieldName RPAREN
+    | CONVERT_CURRENCY LPAREN fieldName RPAREN
     ;
 
  dateFieldName
@@ -865,7 +866,9 @@ fieldSpec
 
 fieldList
     : soslId (COMMA fieldList)*
-    | TOLABEL LPAREN soslId RPAREN
+    | TOLABEL LPAREN soslId RPAREN soslId?
+    | CONVERT_CURRENCY LPAREN soslId RPAREN soslId?
+    | FORMAT LPAREN (soslId | soqlFunction) RPAREN soslId?
     ;
 
 updateList
@@ -965,6 +968,7 @@ id
     | DISTANCE
     | GEOLOCATION
     | GROUPING
+    | CONVERT_CURRENCY
     // SOQL date functions
     | CALENDAR_MONTH
     | CALENDAR_QUARTER
@@ -1164,6 +1168,7 @@ anyId
     | DISTANCE
     | GEOLOCATION
     | GROUPING
+    | CONVERT_CURRENCY
     // SOQL date functions
     | CALENDAR_MONTH
     | CALENDAR_QUARTER

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
@@ -130,4 +130,38 @@ public class SOQLParserTest {
         assertNotNull(context);
         assertEquals(0, parserAndCounter.getValue().getNumErrors());
     }
+
+    @Test
+    void testConvertCurrency() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                "[ SELECT convertCurrency(Amount) FROM Opportunity ]"
+        );
+        ApexParser.SoqlLiteralContext context = parserAndCounter.getKey().soqlLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testConvertCurrencyWithFormat() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                "[\n" +
+                "SELECT Amount, FORMAT(amount) Amt, convertCurrency(amount) convertedAmount,\n" +
+                "    FORMAT(convertCurrency(amount)) convertedCurrency\n" +
+                "FROM Opportunity where id = '006R00000024gDtIAI'\n" +
+                "]"
+        );
+        ApexParser.SoqlLiteralContext context = parserAndCounter.getKey().soqlLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testFormatWithAggregate() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                "[ SELECT FORMAT(MIN(closedate)) Amt FROM opportunity ]"
+        );
+        ApexParser.SoqlLiteralContext context = parserAndCounter.getKey().soqlLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
 }

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SOSLParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SOSLParserTest.java
@@ -84,4 +84,43 @@ public class SOSLParserTest {
         assertNotNull(context);
         assertEquals(0, parserAndCounter.getValue().getNumErrors());
     }
+
+    @Test
+    void testToLabelWithAlias() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                "[FIND :searchTerm IN ALL FIELDS RETURNING Account(Id, toLabel(Name) AliasName) LIMIT 10]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testConvertCurrency() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                "[ FIND 'test' RETURNING Opportunity(Name, convertCurrency(Amount), convertCurrency(Amount) AliasCurrency) ]"
+        );
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testConvertCurrencyWithFormat() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                "[ FIND 'Acme' RETURNING Account(AnnualRevenue, FORMAT(convertCurrency(AnnualRevenue)) convertedCurrency) ]"
+        );
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testFormatWithAggregate() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                "[ FIND 'Acme' RETURNING Account(AnnualRevenue, FORMAT(MIN(CloseDate))) ]"
+        );
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
 }

--- a/npm/src/__tests__/SOQLParserTest.ts
+++ b/npm/src/__tests__/SOQLParserTest.ts
@@ -11,7 +11,7 @@
  3. The name of the author may not be used to endorse or promote products
     derived from this software without specific prior written permission.
  */
-import { QueryContext, StatementContext } from "../ApexParser";
+import { QueryContext, StatementContext, SoqlLiteralContext } from "../ApexParser";
 import { createParser } from "./SyntaxErrorCounter";
 
 test("SOQL Query", () => {
@@ -137,4 +137,38 @@ test("Grouping function", () => {
 
   expect(context).toBeInstanceOf(QueryContext);
   expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("Convert Currency function", () => {
+    const [parser, errorCounter] = createParser(
+        '[ SELECT convertCurrency(Amount) FROM Opportunity ]'
+    );
+    const context = parser.soqlLiteral();
+
+    expect(context).toBeInstanceOf(SoqlLiteralContext);
+    expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("Convert Currency with format", () => {
+    const [parser, errorCounter] = createParser(
+        `[
+            SELECT Amount, FORMAT(amount) Amt, convertCurrency(amount) convertedAmount,
+                FORMAT(convertCurrency(amount)) convertedCurrency
+            FROM Opportunity where id = '006R00000024gDtIAI'
+        ]`
+    );
+    const context = parser.soqlLiteral();
+
+    expect(context).toBeInstanceOf(SoqlLiteralContext);
+    expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("Format function with aggregate", () => {
+    const [parser, errorCounter] = createParser(
+        '[ SELECT FORMAT(MIN(closedate)) Amt FROM opportunity ]'
+    )
+    const context = parser.soqlLiteral();
+
+    expect(context).toBeInstanceOf(SoqlLiteralContext);
+    expect(errorCounter.getNumErrors()).toEqual(0);
 });

--- a/npm/src/__tests__/SOSLParserTest.ts
+++ b/npm/src/__tests__/SOSLParserTest.ts
@@ -88,3 +88,51 @@ test('testToLabel', () => {
     expect(context).toBeInstanceOf(SoslLiteralContext)
     expect(errorCounter.getNumErrors()).toEqual(0)
 })
+
+test('testToLabelWithAlias', () => {
+    const [parser, errorCounter] = createParser(
+        "[FIND :searchTerm IN ALL FIELDS RETURNING Account(Id, toLabel(Name) AliasName) LIMIT 10]")
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})
+
+test('testConvertCurrency', () => {
+    const [parser, errorCounter] = createParser(
+        `[
+            FIND 'test' RETURNING Opportunity(
+                Name,
+                convertCurrency(Amount),
+                convertCurrency(Amount) AliasCurrency
+            )
+        ]`)
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})
+
+test('testConvertCurrencyWithFormat', () => {
+    const [parser, errorCounter] = createParser(
+        `[
+            FIND 'Acme' RETURNING Account(
+                AnnualRevenue,
+                FORMAT(convertCurrency(AnnualRevenue)) convertedCurrency
+            )
+        ]`)
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})
+
+test('testFormatWithAggregate', () => {
+    const [parser, errorCounter] = createParser(
+        "[ FIND 'Acme' RETURNING Account(AnnualRevenue, FORMAT(MIN(CloseDate))) ]"
+    )
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})


### PR DESCRIPTION
Additionally:
- support nested functions in FORMAT()
- support FORMAT() in SOSL
- support aliasing for toLabel() in SOSL

Originally reported at https://github.com/pmd/pmd/issues/5228

Docs:
- [SOQL convertCurrency()](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_querying_currency_fields.htm)
- [SOQL FORMAT()](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_format.htm)
- [SOSL convertCurrency()](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_sosl_querying_currency_fields.htm)
- [SOSL FORMAT()](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_sosl_format.htm)
- [SOSL toLabel(fields)](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_sosl_tolabel.htm)