### PR TITLE
Support time literals in SOQL queries

### DIFF
--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -235,9 +235,10 @@ NEXT_N_FISCAL_YEARS_N     : 'next_n_fiscal_years';
 LAST_N_FISCAL_YEARS_N     : 'last_n_fiscal_years';
 N_FISCAL_YEARS_AGO_N      : 'n_fiscal_years_ago';
 
-// SOQL Date literal
+// SOQL Date and Time literals
 DateLiteral: Digit Digit Digit Digit '-' Digit Digit '-' Digit Digit;
-DateTimeLiteral: DateLiteral 't' Digit Digit ':' Digit Digit ':' Digit Digit ('z' | (('+' | '-') Digit+ ( ':' Digit+)? ));
+TimeLiteral: Digit Digit ':' Digit Digit ':' Digit Digit ('.' Digit+ )? ('z' | (('+' | '-') Digit+ ( ':' Digit+)? ));
+DateTimeLiteral: DateLiteral 't' TimeLiteral;
 
 // SOQL Currency literal
 // (NOTE: this is also a valid Identifier)

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -696,6 +696,7 @@ value
     | signedNumber
     | StringLiteral
     | DateLiteral
+    | TimeLiteral
     | DateTimeLiteral
     | dateFormula
     | IntegralCurrencyLiteral (DOT IntegerLiteral?)?

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
@@ -164,4 +164,14 @@ public class SOQLParserTest {
         assertNotNull(context);
         assertEquals(0, parserAndCounter.getValue().getNumErrors());
     }
+
+    @Test
+    void timeLiteral() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+            "[SELECT Break__c,Check_Out__c FROM VMS_Time_Card_Item__c WHERE Time_Card__c =:timeCard.Id AND Check_Out__c = 01:00:00.000Z]"
+        );
+        ApexParser.SoqlLiteralContext context = parserAndCounter.getKey().soqlLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
 }

--- a/npm/src/__tests__/SOQLParserTest.ts
+++ b/npm/src/__tests__/SOQLParserTest.ts
@@ -172,3 +172,13 @@ test("Format function with aggregate", () => {
     expect(context).toBeInstanceOf(SoqlLiteralContext);
     expect(errorCounter.getNumErrors()).toEqual(0);
 });
+
+test("Time Literal", () => {
+    const [parser, errorCounter] = createParser(
+        '[SELECT Break__c,Check_Out__c FROM VMS_Time_Card_Item__c WHERE Time_Card__c =:timeCard.Id AND Check_Out__c = 01:00:00.000Z]'
+    )
+    const context = parser.soqlLiteral();
+
+    expect(context).toBeInstanceOf(SoqlLiteralContext);
+    expect(errorCounter.getNumErrors()).toEqual(0);
+});


### PR DESCRIPTION
Fixes #58

There is no clear specification on https://developer.salesforce.com/docs/atlas.en-us.252.0.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_dateformats.htm - only for dates.

But time literals seem to be possible as well, e.g. https://salesforce.stackexchange.com/questions/370738/how-do-i-use-a-time-literal-in-a-soql-query

