### PR TITLE
fix: reorder memberDeclaration alternatives to prioritize class over field

### DIFF
--- a/antlr/BaseApexParser.g4
+++ b/antlr/BaseApexParser.g4
@@ -144,30 +144,30 @@ modifier
 
 memberDeclaration
     : methodDeclaration
-    | fieldDeclaration
     | constructorDeclaration
     | interfaceDeclaration
     | classDeclaration
     | enumDeclaration
     | propertyDeclaration
+    | fieldDeclaration
     ;
 
 triggerMemberDeclaration
     : methodDeclaration
-    | fieldDeclaration
     | interfaceDeclaration
     | classDeclaration
     | enumDeclaration
     | propertyDeclaration
+    | fieldDeclaration
     ;
 
 anonymousMemberDeclaration
     : methodDeclaration
-    | fieldDeclaration
     | interfaceDeclaration
     | classDeclaration
     | enumDeclaration
     | propertyDeclaration
+    | fieldDeclaration
     ;
 
 /* We use rule this even for void methods which cannot have [] after parameters.


### PR DESCRIPTION
This fixes an issue where virtual inner classes were incorrectly parsed as fields.

The grammar now tries class/interface/enum declarations before field declarations, giving priority to specific keywords (CLASS, INTERFACE, ENUM) over the general typeRef pattern used in field declarations.

repro code from one of our test cases y'all might recognize;
```
public class FFLIB_MetadataService{
  public virtual class GlobalPicklistValue extends Metadata {
    public String color;
    public Boolean default_x;
    public String description;
    public Boolean isActive;
  }

  public virtual class Metadata {
    public String fullName;
  }
}
```

am open to other approaches (ex: trying to make the selector for fieldDeclaration tighter so that it looks ahead and excludes `class` keyword but I'm not good enough at antlr to know how to do that. 