### PR TITLE
release/v4 - chore: update maven publish to use central portal

### DIFF
--- a/.github/workflows/PublishMaven.yml
+++ b/.github/workflows/PublishMaven.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: "8"
           distribution: "temurin"
           cache: "maven"
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_TOKEN
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -29,7 +29,7 @@
     <url>http://github.com/apex-dev-tools/apex-parser.git</url>
   </scm>
 
-  <!-- https://central.sonatype.org/pages/ossrh-guide.html -->
+  <!-- https://central.sonatype.org/publish/publish-portal-maven -->
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -37,18 +37,9 @@
 
   <repositories>
     <repository>
-      <id>oss.sonatype.org</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>snapshots-oss.sonatype.org</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -76,13 +67,9 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
   </distributionManagement>
 
   <build>
@@ -170,14 +157,13 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
OSSRH is now shut down.