### PR TITLE
Temporarily bundle antlr4 until fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@
 - **(BREAKING)** Updated to ES Module format. Node 20/22, TypeScript 5.9 support `require(esm)`.
   - Increased min node version to 20.
   - `antlr4` has to be patched to fix module resolution of the type declaration files.
-    - The patch can be copied to `patches/*` and applied with `patch-package` if needed.
-    - Until it is fixed, imports of `antlr4` will cause type errors (`skipLibCheck` can be used in some cases).
+    - The patch is applied to a bundled version of the package.
+    - For reference it is also published under `patches/*`.
 
 - **(BREAKING)** Re-exported antlr classes `CommonTokenStream` and `ParseTreeWalker` removed.
   - Added type aliases like `ApexTokenStream`, `ApexParseTree`, and more to use with listener/visitor/walker.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "@apexdevtools/apex-parser",
       "version": "5.0.0-beta.4",
-      "hasInstallScript": true,
+      "bundleDependencies": [
+        "antlr4"
+      ],
       "license": "BSD-3-Clause",
       "dependencies": {
         "antlr4": "4.13.2"
@@ -2325,6 +2327,7 @@
       "version": "4.13.2",
       "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.2.tgz",
       "integrity": "sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==",
+      "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16"

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/apex-parser",
-      "version": "5.0.0-beta.4",
+      "version": "5.0.0-beta.5",
       "bundleDependencies": [
         "antlr4"
       ],

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "description": "Javascript parser for Salesforce Apex Language",
   "author": "Apex Dev Tools Team <apexdevtools@gmail.com> (https://github.com/apex-dev-tools)",
   "bugs": "https://github.com/apex-dev-tools/apex-parser/issues",

--- a/npm/package.json
+++ b/npm/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist",
     "init": "npm ci && npm run antlr",
     "lint": "eslint --cache --cache-location .eslintcache ./src --fix",
-    "postinstall": "patch-package",
+    "prepare": "patch-package",
     "prepack": "cp ../*.md .",
     "test": "jest --config jestconfig.json",
     "test:samples": "jest --config sys.jestconfig.json",
@@ -31,6 +31,9 @@
     "dist/src",
     "patches",
     "CHANGELOG.md"
+  ],
+  "bundleDependencies": [
+    "antlr4"
   ],
   "dependencies": {
     "antlr4": "4.13.2"


### PR DESCRIPTION
To avoid needing `patch-package` in every consumer - try to bundle a patched version of antlr in the parser package. As long as the `Apex-` type aliases are used instead, and antlr4 is not directly referenced/imported this should be a reasonable compromise.