### PR TITLE
chore: bump to 5.1.0-beta.1 post-5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # apex-parser - Changelog
 
-## 5.0.0
+## 5.1.0-beta.1
+
+- Allow functions in `GROUP BY` clause of SOQL queries
+
+## 5.0.0 - 2026-04-21
 
 ## General
 

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>apex-parser</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>apex-parser</name>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "5.0.0-beta.5",
+  "version": "5.1.0-beta.1",
   "description": "Javascript parser for Salesforce Apex Language",
   "author": "Apex Dev Tools Team <apexdevtools@gmail.com> (https://github.com/apex-dev-tools)",
   "bugs": "https://github.com/apex-dev-tools/apex-parser/issues",


### PR DESCRIPTION
## Summary

Sets main up for the next release cycle after 5.0.0 shipped.

- `npm/package.json`: `5.0.0-beta.5` → `5.1.0-beta.1`
- `jvm/pom.xml`: `5.0.0-SNAPSHOT` → `5.1.0-SNAPSHOT`
- `CHANGELOG.md`: dates the 5.0.0 heading (`2026-04-21`) and adds a new `5.1.0-beta.1` section covering #85 (functions in SOQL `GROUP BY`)

## Context

5.0.0 is now published on both npm (`latest` tag) and Maven Central. The release cut was done on the `release/v5.0.0` branch (based on the `v5.0.0-beta.5` tag target, before #85), so #85 will ship in 5.1.0.

## Test plan

- [ ] CI build passes
- [ ] After merge, snapshot publishes continue to land at `central.sonatype.com/repository/maven-snapshots` under `5.1.0-SNAPSHOT`