### PR TITLE
feat: add createLexerAndParser helper for unified error listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ const listener = new Listener();
 ApexParseTreeWalker.DEFAULT.walk(listener, parser.compilationUnit());
 ```
 
+### Capturing syntax errors
+
+Lexer errors (e.g. invalid string escape sequences) are only reported to listeners attached to the lexer, while parser errors are only reported to listeners attached to the parser. To capture both from a single listener, use `createLexerAndParser`, which wires the listener to both:
+
+```typescript
+import { ApexParserFactory, ApexErrorListener } from "@apexdevtools/apex-parser";
+
+class MyListener extends ApexErrorListener {
+  apexSyntaxError(line: number, column: number, msg: string): void {
+    console.log(`${line}:${column} ${msg}`);
+  }
+}
+
+const { parser } = ApexParserFactory.createLexerAndParser(source, new MyListener());
+parser.compilationUnit();
+```
+
+The Java API is equivalent:
+
+```java
+ApexErrorListener listener = new MyListener();
+LexerAndParser pair = ApexParserFactory.createLexerAndParser(
+  CharStreams.fromString(source), listener);
+pair.getParser().compilationUnit();
+```
+
 ### SOSL FIND quoting
 
 SOSL FIND uses ' as a quoting character when embedded in Apex, in the API braces are used:

--- a/jvm/src/main/java/io/github/apexdevtools/apexparser/ApexParserFactory.java
+++ b/jvm/src/main/java/io/github/apexdevtools/apexparser/ApexParserFactory.java
@@ -57,4 +57,42 @@ public final class ApexParserFactory {
     lexer.removeErrorListeners();
     return lexer;
   }
+
+  /**
+   * Creates a lexer and parser pair with the given error listener attached to
+   * both. This is the recommended way to capture all syntax errors when parsing
+   * full Apex source - lexer errors (e.g. invalid string escape sequences) are
+   * only reported to listeners attached to the lexer, and parser errors are
+   * only reported to listeners attached to the parser.
+   */
+  public static LexerAndParser createLexerAndParser(
+    CharStream stream,
+    ApexErrorListener errorListener
+  ) {
+    ApexLexer lexer = createLexer(stream);
+    lexer.addErrorListener(errorListener);
+    ApexParser parser = createParser(new CommonTokenStream(lexer));
+    parser.addErrorListener(errorListener);
+    return new LexerAndParser(lexer, parser);
+  }
+
+  /** Holder for a paired {@link ApexLexer} and {@link ApexParser}. */
+  public static final class LexerAndParser {
+
+    private final ApexLexer lexer;
+    private final ApexParser parser;
+
+    LexerAndParser(ApexLexer lexer, ApexParser parser) {
+      this.lexer = lexer;
+      this.parser = parser;
+    }
+
+    public ApexLexer getLexer() {
+      return lexer;
+    }
+
+    public ApexParser getParser() {
+      return parser;
+    }
+  }
 }

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexLexerTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexLexerTest.java
@@ -14,8 +14,11 @@
 package io.github.apexdevtools.apexparser;
 
 import static io.github.apexdevtools.apexparser.SyntaxErrorCounter.createLexer;
+import static io.github.apexdevtools.apexparser.SyntaxErrorCounter.createLexerAndParser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.apexdevtools.apexparser.ApexParserFactory.LexerAndParser;
 import java.util.Map;
 import org.antlr.v4.runtime.*;
 import org.junit.jupiter.api.Test;
@@ -86,5 +89,13 @@ public class ApexLexerTest {
     CommonTokenStream tokens = new CommonTokenStream(lexerAndCounter.getKey());
     assertEquals(2, tokens.getNumberOfOnChannelTokens());
     assertEquals(0, lexerAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
+  void testLexerErrorCapturedViaCreateLexerAndParser() {
+    Map.Entry<LexerAndParser, SyntaxErrorCounter> pairAndCounter =
+      createLexerAndParser("public class X { String s = '\\q'; }");
+    pairAndCounter.getKey().getParser().compilationUnit();
+    assertTrue(pairAndCounter.getValue().getNumErrors() > 0);
   }
 }

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SyntaxErrorCounter.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SyntaxErrorCounter.java
@@ -13,23 +13,17 @@
  */
 package io.github.apexdevtools.apexparser;
 
+import io.github.apexdevtools.apexparser.ApexParserFactory.LexerAndParser;
 import java.util.AbstractMap;
 import java.util.Map;
-import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.CharStreams;
 
-public class SyntaxErrorCounter extends BaseErrorListener {
+public class SyntaxErrorCounter extends ApexErrorListener {
 
   private int numErrors = 0;
 
   @Override
-  public void syntaxError(
-    Recognizer<?, ?> recognizer,
-    Object offendingSymbol,
-    int line,
-    int charPositionInLine,
-    String msg,
-    RecognitionException e
-  ) {
+  public void apexSyntaxError(int line, int column, String msg) {
     this.numErrors += 1;
   }
 
@@ -59,5 +53,17 @@ public class SyntaxErrorCounter extends BaseErrorListener {
     parser.addErrorListener(errorCounter);
 
     return new AbstractMap.SimpleEntry<>(parser, errorCounter);
+  }
+
+  public static Map.Entry<
+    LexerAndParser,
+    SyntaxErrorCounter
+  > createLexerAndParser(String input) {
+    SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+    LexerAndParser pair = ApexParserFactory.createLexerAndParser(
+      CharStreams.fromString(input),
+      errorCounter
+    );
+    return new AbstractMap.SimpleEntry<>(pair, errorCounter);
   }
 }

--- a/npm/src/ApexErrorListener.ts
+++ b/npm/src/ApexErrorListener.ts
@@ -35,14 +35,15 @@ import {
 /**
  * Base `ErrorListener` for Apex parsers.
  *
- * Implement `apexSyntaxError()` to set behaviour.
+ * Implement `apexSyntaxError()` to set behaviour. A single instance can be
+ * attached to both a lexer and a parser - see `ApexParserFactory.createLexerAndParser`.
  */
-export abstract class ApexErrorListener extends ErrorListener<Token> {
+export abstract class ApexErrorListener extends ErrorListener<Token | number> {
   abstract apexSyntaxError(line: number, column: number, msg: string): void;
 
   syntaxError(
-    recognizer: Recognizer<Token>,
-    offendingSymbol: Token,
+    recognizer: Recognizer<Token | number>,
+    offendingSymbol: Token | number,
     line: number,
     column: number,
     msg: string,

--- a/npm/src/ApexParserFactory.ts
+++ b/npm/src/ApexParserFactory.ts
@@ -43,7 +43,10 @@ import type ApexParserListener from "./antlr/ApexParserListener.js";
 import type ApexParserVisitor from "./antlr/ApexParserVisitor.js";
 import ApexLexer from "./antlr/ApexLexer.js";
 import ApexParser from "./antlr/ApexParser.js";
-import { ThrowingErrorListener } from "./ApexErrorListener.js";
+import {
+  ApexErrorListener,
+  ThrowingErrorListener,
+} from "./ApexErrorListener.js";
 
 export type ApexParserRuleContext = ParserRuleContext;
 export type ApexErrorNode = ErrorNode;
@@ -90,6 +93,24 @@ export class ApexParserFactory {
     // always remove default console listener
     lexer.removeErrorListeners();
     return lexer;
+  }
+
+  /**
+   * Creates a lexer and parser pair with the given error listener attached to
+   * both. This is the recommended way to capture all syntax errors when parsing
+   * full Apex source - lexer errors (e.g. invalid string escape sequences) are
+   * only reported to listeners attached to the lexer, and parser errors are
+   * only reported to listeners attached to the parser.
+   */
+  static createLexerAndParser(
+    source: string,
+    errorListener: ApexErrorListener
+  ): { lexer: ApexLexer; parser: ApexParser } {
+    const lexer = this.createLexer(source);
+    lexer.addErrorListener(errorListener);
+    const parser = this.createParser(new CommonTokenStream(lexer));
+    parser.addErrorListener(errorListener);
+    return { lexer, parser };
   }
 }
 

--- a/npm/test/ApexLexerTest.ts
+++ b/npm/test/ApexLexerTest.ts
@@ -12,7 +12,11 @@
     derived from this software without specific prior written permission.
  */
 import { CommonTokenStream } from "antlr4";
-import { createLexer, SyntaxErrorCounter } from "./SyntaxErrorCounter.js";
+import {
+  createLexer,
+  createLexerAndParser,
+  SyntaxErrorCounter,
+} from "./SyntaxErrorCounter.js";
 import { CaseInsensitiveInputStream } from "../src/CaseInsensitiveInputStream.js";
 import ApexLexer from "../src/antlr/ApexLexer.js";
 
@@ -54,7 +58,7 @@ test("Case insensitivity (deprecated stream)", () => {
   // intentional testing deprecated type backward compat
   const lexer = new ApexLexer(new CaseInsensitiveInputStream("PuBliC"));
   lexer.removeErrorListeners();
-  const errorCounter = new SyntaxErrorCounter<number>();
+  const errorCounter = new SyntaxErrorCounter();
   lexer.addErrorListener(errorCounter);
 
   const tokens = new CommonTokenStream(lexer) as ExtCommonTokenStream;
@@ -67,4 +71,12 @@ test("Lexer unicode escapes", () => {
   const tokens = new CommonTokenStream(lexer) as ExtCommonTokenStream;
   expect(tokens.getNumberOfOnChannelTokens()).toBe(2);
   expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("Lexer error is captured via createLexerAndParser", () => {
+  const { parser, errorCounter } = createLexerAndParser(
+    "public class X { String s = '\\q'; }"
+  );
+  parser.compilationUnit();
+  expect(errorCounter.getNumErrors()).toBeGreaterThan(0);
 });

--- a/npm/test/SyntaxErrorCounter.ts
+++ b/npm/test/SyntaxErrorCounter.ts
@@ -11,22 +11,15 @@
  3. The name of the author may not be used to endorse or promote products
     derived from this software without specific prior written permission.
  */
-import { ErrorListener, RecognitionException, Recognizer, Token } from "antlr4";
 import ApexLexer from "../src/antlr/ApexLexer.js";
 import ApexParser from "../src/antlr/ApexParser.js";
+import { ApexErrorListener } from "../src/ApexErrorListener.js";
 import { ApexParserFactory } from "../src/ApexParserFactory.js";
 
-export class SyntaxErrorCounter<T = Token> extends ErrorListener<T> {
+export class SyntaxErrorCounter extends ApexErrorListener {
   numErrors = 0;
 
-  syntaxError(
-    recognizer: Recognizer<T>,
-    offendingSymbol: T,
-    line: number,
-    column: number,
-    msg: string,
-    e: RecognitionException | undefined
-  ): void {
+  apexSyntaxError(line: number, column: number, msg: string): void {
     this.numErrors += 1;
   }
 
@@ -35,11 +28,9 @@ export class SyntaxErrorCounter<T = Token> extends ErrorListener<T> {
   }
 }
 
-export function createLexer(
-  input: string
-): [ApexLexer, SyntaxErrorCounter<number>] {
+export function createLexer(input: string): [ApexLexer, SyntaxErrorCounter] {
   const lexer = ApexParserFactory.createLexer(input);
-  const errorCounter = new SyntaxErrorCounter<number>();
+  const errorCounter = new SyntaxErrorCounter();
   lexer.addErrorListener(errorCounter);
 
   return [lexer, errorCounter];
@@ -51,4 +42,17 @@ export function createParser(input: string): [ApexParser, SyntaxErrorCounter] {
   parser.addErrorListener(errorCounter);
 
   return [parser, errorCounter];
+}
+
+export function createLexerAndParser(input: string): {
+  lexer: ApexLexer;
+  parser: ApexParser;
+  errorCounter: SyntaxErrorCounter;
+} {
+  const errorCounter = new SyntaxErrorCounter();
+  const { lexer, parser } = ApexParserFactory.createLexerAndParser(
+    input,
+    errorCounter
+  );
+  return { lexer, parser, errorCounter };
 }


### PR DESCRIPTION
## Summary

- Adds `ApexParserFactory.createLexerAndParser(source, listener)` to both the TS and Java packages. The listener is required and wired to both the lexer and the parser, so a single `ApexErrorListener` instance captures lexer-level errors (e.g. invalid string escapes) alongside parser errors.
- Widens the TS `ApexErrorListener` base class generic to `Token | number` so one listener instance can be attached to both recognizers.
- Updates README with a "Capturing syntax errors" section showing the recommended pattern in both languages.

Closes #83

## Test plan

- [x] `mvn test` (jvm) — 73 tests pass
- [x] `npm test` (npm) — 74 tests pass
- [x] `npx prettier --check` and `npx eslint` on changed files — clean
- [x] CI green