### PR TITLE
fix: support fully-qualified enum values in switch when clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 5.1.0-beta.1
 
 - Allow functions in `GROUP BY` clause of SOQL queries
+- Support fully-qualified enum values in switch `when` clauses, e.g. `when MyClass.MyEnum.VALUE`
+  - `whenLiteral` now matches `qualifiedName` in place of `id`, so bare enum values like `when VALUE` now parse as `WhenLiteral > qualifiedName > id` rather than `WhenLiteral > id` (AST shape change for tree-walking consumers)
 
 ## 5.0.0 - 2026-04-21
 

--- a/antlr/BaseApexParser.g4
+++ b/antlr/BaseApexParser.g4
@@ -341,7 +341,7 @@ whenLiteral
     | (SUB|ADD)* LongLiteral
     | StringLiteral
     | NULL
-    | id
+    | qualifiedName
     // Salesforce tolerates paren pairs around each literal,
     // although this is not explicitly documented.
     | LPAREN whenLiteral RPAREN

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexParserTest.java
@@ -223,6 +223,20 @@ public class ApexParserTest {
   }
 
   @Test
+  void testWhenQualifiedEnumValue() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "switch on (x) { \n" +
+      "  when MyEnum.A { return 1; } \n" +
+      "  when MyClass.MyEnum.B { return 2; } \n" +
+      "  when MyEnum.C, MyEnum.D { return 3; } \n" +
+      "}"
+    );
+    ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
   void testWhenLiteralSigns() {
     Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
       "switch on (x) { \n" +

--- a/npm/test/ApexParserTest.ts
+++ b/npm/test/ApexParserTest.ts
@@ -226,6 +226,20 @@ test("testWhenLiteralParens", () => {
   expect(errorCounter.getNumErrors()).toEqual(0);
 });
 
+test("testWhenQualifiedEnumValue", () => {
+  const [parser, errorCounter] = createParser(`
+      switch on (x) {
+          when MyEnum.A { return 1; }
+          when MyClass.MyEnum.B { return 2; }
+          when MyEnum.C, MyEnum.D { return 3; }
+       }`);
+
+  const context = parser.statement();
+
+  expect(context).toBeInstanceOf(StatementContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
 test("testSoqlModeKeywords", () => {
   const MODES = ["USER_MODE", "SYSTEM_MODE"];
   for (const mode of MODES) {


### PR DESCRIPTION
## Summary

Fixes #63. Changes `whenLiteral` in the grammar to match `qualifiedName` in place of `id`, so dotted enum references like `when MyEnum.VALUE` and `when MyClass.MyEnum.VALUE` parse.

Previously these failed: the parser picked the `typeRef id` alternative and let `typeRef` greedily consume the entire dotted chain, leaving no trailing identifier to satisfy the `id` slot.

## AST shape note

`when VALUE {}` still parses cleanly, but now produces `WhenLiteral > qualifiedName > id` rather than `WhenLiteral > id`. Tree-walking consumers that descend into `WhenLiteral` will need to account for the extra `qualifiedName` node. Flagged in CHANGELOG.

## Semantic note

The grammar does not syntactically disambiguate `when Foo {}` — it could be an enum constant or a class-constant reference. That was true before this change as well and is unavoidable without type information. The only ambiguity this change introduces is between dotted enum values (`whenLiteral`) and namespaced SObject bindings (`typeRef id`) — LL(*) prediction picks the correct alternative based on whether a trailing bare identifier is present, so `when MyEnum.VALUE {}` → whenLiteral and `when ns.Account acc {}` → typeRef id.

## Precedent

Grammar corrections have historically shipped in minor/patch versions. The closest prior is 4.3.1: "Fix parser whenValue to support type refs". Targeting 5.1.0.

## Test plan

- [x] `npm test` — 75/75 pass (was 74), including new `testWhenQualifiedEnumValue`
- [x] `mvn test` (jvm) — 74/74 pass (was 73), including new `testWhenQualifiedEnumValue`
- [x] Manual probe: `MyEnum.VALUE`, `MyClass.MyEnum.VALUE`, comma-separated dotted enums all parse; `Account acc`, `ns.Account acc`, literals, `null`, `else` all unchanged
- [x] `npm run lint` clean