### PR TITLE
chore: ignore JUnit and @types/node major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,11 @@ updates:
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # @types/node tracks the Node runtime version; pin to the LTS line
+      # declared in engines.node rather than chasing current Node majors.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "maven"
     directory: "/jvm"
@@ -36,6 +41,11 @@ updates:
     groups:
       maven-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # JUnit 6 requires Java 17+; the build targets <release>8</release>.
+      # Revisit if/when the Java baseline is bumped.
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "maven"
     directory: "/npm"


### PR DESCRIPTION
## Summary

Prevents Dependabot from re-opening two major-version bumps that don't fit the project's current constraints:

- **`org.junit.jupiter:junit-jupiter`** — JUnit 6 requires Java 17+, but `jvm/pom.xml` pins `<release>8</release>`. PR #93 failed CI for exactly this reason. Ignore scope: majors only; minor/patch bumps continue to flow.
- **`@types/node`** — should track the Node LTS declared in `engines.node` (currently 22), not the current Node major line. Type-only PRs like #94 pass CI because types erase at runtime, but semantically the type surface should match the runtime we target.

Both ignore rules are scoped to `version-update:semver-major`. Security advisories would still open PRs regardless.

## Test plan

- [x] YAML syntax valid (verified by re-reading the file)
- [ ] Next Dependabot schedule run doesn't re-open either as an independent major PR