### PR TITLE
chore: bump typescript to v6

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -21,7 +21,7 @@
         "eslint": "^10.2.1",
         "jest": "^30.3.0",
         "patch-package": "^8.0.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.0"
       },
       "engines": {
@@ -5756,9 +5756,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -45,7 +45,7 @@
     "eslint": "^10.2.1",
     "jest": "^30.3.0",
     "patch-package": "^8.0.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0"
   },
   "engines": {

--- a/npm/tsconfig.json
+++ b/npm/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "declaration": true,
     "strict": true,
-    "allowJs": true
+    "allowJs": true,
+    "types": ["node", "jest"]
   },
   "include": [
     "src",


### PR DESCRIPTION
## Summary

Supersedes Dependabot PR #95. Two tightly-coupled changes:

- `typescript` 5.9.3 → 6.0.3
- `tsconfig.json`: add `"types": ["node", "jest"]`

TypeScript 6 removed the automatic inclusion of every `@types/*` package in `node_modules` — ambient type deps now need to be declared explicitly. That explains why #95 failed CI with `Cannot find name 'Buffer' / 'process'`. The `types` array covers what `src/Check.ts` and the test files actually use.

`typescript-eslint@8.59.0`'s peer-dep range is `>=4.8.4 <6.1.0`, so it already supports TS 6 — no tseslint bump needed.

## Consumer impact

**None.** Verified by building `src/` under both TS 5.9.3 and TS 6.0.3 and running `diff -r` over the two `dist/` trees: zero differences in either `.js` or `.d.ts` output. Downstream projects on any TS version continue to see identical types.

## Test plan

- [x] `npm install` clean (0 vulns, no peer-dep warnings)
- [x] `npm run lint` — clean exit
- [x] `npm run build` — BUILD SUCCESS under TS 6
- [x] `npm test` — 76/76 tests pass
- [x] `diff -r dist-ts5 dist-ts6` — no differences
- [ ] CI Build workflow passes