### PR TITLE
feat: add lexer/parser support for Summer '26 multi-line strings (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Support Apex bind variables (`:expr`) in SOSL `WITH DIVISION` clause
 - Support fully-qualified enum values in switch `when` clauses, e.g. `when MyClass.MyEnum.VALUE`
   - `whenLiteral` now matches `qualifiedName` in place of `id`, so bare enum values like `when VALUE` now parse as `WhenLiteral > qualifiedName > id` rather than `WhenLiteral > id` (AST shape change for tree-walking consumers)
+- Support multi-line string literals (Salesforce Summer '26), e.g. `String json = '''<NL>{...}<NL>''';`
+  - New `MultilineStringLiteral` token, accepted alongside `StringLiteral` in literal/SOQL/SOSL contexts.
+  - Body must start on a new line after the opening `'''`, matching platform behaviour. Malformed forms like `'''abc'''` continue to lex as legacy `StringLiteral` tokens (`''`, `'abc'`, `''`); apex-ls consumes this pattern to surface a targeted diagnostic (apex-ls#443).
 
 ## 5.0.0 - 2026-04-21
 

--- a/antlr/BaseApexLexer.g4
+++ b/antlr/BaseApexLexer.g4
@@ -330,8 +330,10 @@ BooleanLiteral
 // part of the token but conventionally stripped at runtime by the platform.
 // Declared before StringLiteral so longest-match prefers '''...''' over the
 // degenerate ''+'...'+'' fallback when a newline follows the opening.
+// Backslashes must form a valid EscapeSequence (matching StringLiteral
+// semantics — '\q' is rejected in both single- and triple-quoted forms).
 MultilineStringLiteral
-    :   '\'\'\'' [\r\n] ( EscapeSequence | . )*? '\'\'\''
+    :   '\'\'\'' [\r\n] ( EscapeSequence | '\'' | ~['\\] )*? '\'\'\''
     ;
 
 StringLiteral

--- a/antlr/BaseApexLexer.g4
+++ b/antlr/BaseApexLexer.g4
@@ -325,6 +325,15 @@ BooleanLiteral
 
 // §3.10.5 String Literals
 
+// Multi-line strings (Salesforce Summer '26).
+// Body must start on a new line after the opening '''. The first newline is
+// part of the token but conventionally stripped at runtime by the platform.
+// Declared before StringLiteral so longest-match prefers '''...''' over the
+// degenerate ''+'...'+'' fallback when a newline follows the opening.
+MultilineStringLiteral
+    :   '\'\'\'' [\r\n] ( EscapeSequence | . )*? '\'\'\''
+    ;
+
 StringLiteral
     :   '\'' StringCharacters? '\''
     ;

--- a/antlr/BaseApexParser.g4
+++ b/antlr/BaseApexParser.g4
@@ -252,6 +252,7 @@ literal
     | LongLiteral
     | NumberLiteral
     | StringLiteral
+    | MultilineStringLiteral
     | BooleanLiteral
     | NULL
     ;
@@ -340,6 +341,7 @@ whenLiteral
     : (SUB|ADD)* IntegerLiteral
     | (SUB|ADD)* LongLiteral
     | StringLiteral
+    | MultilineStringLiteral
     | NULL
     | qualifiedName
     // Salesforce tolerates paren pairs around each literal,
@@ -654,7 +656,7 @@ soqlFunction
     | WEEK_IN_MONTH LPAREN dateFieldName RPAREN
     | WEEK_IN_YEAR LPAREN dateFieldName RPAREN
     | FIELDS LPAREN soqlFieldsParameter RPAREN
-    | DISTANCE LPAREN locationValue COMMA locationValue COMMA StringLiteral RPAREN
+    | DISTANCE LPAREN locationValue COMMA locationValue COMMA (StringLiteral | MultilineStringLiteral) RPAREN
     | GROUPING LPAREN fieldName RPAREN
     | CONVERT_CURRENCY LPAREN fieldName RPAREN
     ;
@@ -714,6 +716,7 @@ value
     | BooleanLiteral
     | signedNumber
     | StringLiteral
+    | MultilineStringLiteral
     | DateLiteral
     | TimeLiteral
     | DateTimeLiteral
@@ -866,13 +869,13 @@ soslClauses
     ;
 
 soslWithClause
-    : WITH DIVISION ASSIGN (StringLiteral | boundExpression)
+    : WITH DIVISION ASSIGN (StringLiteral | MultilineStringLiteral | boundExpression)
     | WITH DATA CATEGORY filteringExpression
     | WITH SNIPPET (LPAREN TARGET_LENGTH ASSIGN IntegerLiteral RPAREN)?
     | WITH NETWORK IN LPAREN networkList RPAREN
-    | WITH NETWORK ASSIGN StringLiteral
-    | WITH PRICEBOOKID ASSIGN StringLiteral
-    | WITH METADATA ASSIGN StringLiteral
+    | WITH NETWORK ASSIGN (StringLiteral | MultilineStringLiteral)
+    | WITH PRICEBOOKID ASSIGN (StringLiteral | MultilineStringLiteral)
+    | WITH METADATA ASSIGN (StringLiteral | MultilineStringLiteral)
     | WITH USER_MODE
     | WITH SYSTEM_MODE
     ;
@@ -910,7 +913,7 @@ updateType
     : TRACKING | VIEWSTAT;
 
 networkList
-    : StringLiteral (COMMA networkList)?
+    : (StringLiteral | MultilineStringLiteral) (COMMA networkList)?
     ;
 
 soslId

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexLexerTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexLexerTest.java
@@ -208,4 +208,16 @@ public class ApexLexerTest {
     tokens.fill();
     assertTrue(lc.getValue().getNumErrors() > 0);
   }
+
+  @Test
+  void testMultilineStringInvalidEscape() {
+    // Apex platform rejects '\q' in both single- and triple-quoted strings.
+    // A bare backslash in the body must form a valid EscapeSequence.
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer(
+      "'''\ninvalid \\q here\n'''"
+    );
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertTrue(lc.getValue().getNumErrors() > 0);
+  }
 }

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexLexerTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexLexerTest.java
@@ -98,4 +98,114 @@ public class ApexLexerTest {
     pairAndCounter.getKey().getParser().compilationUnit();
     assertTrue(pairAndCounter.getValue().getNumErrors() > 0);
   }
+
+  // Salesforce Summer '26 multi-line string literals: '''<NL>...'''
+
+  @Test
+  void testMultilineStringBasic() {
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer(
+      "'''\nhello\nworld'''"
+    );
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    assertEquals(2, tokens.getNumberOfOnChannelTokens());
+    assertEquals(ApexLexer.MultilineStringLiteral, tokens.get(0).getType());
+  }
+
+  @Test
+  void testMultilineStringClosingOnOwnLine() {
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer(
+      "'''\nhello\n'''"
+    );
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    assertEquals(ApexLexer.MultilineStringLiteral, tokens.get(0).getType());
+  }
+
+  @Test
+  void testMultilineStringEmptyBody() {
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer("'''\n'''");
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    assertEquals(ApexLexer.MultilineStringLiteral, tokens.get(0).getType());
+  }
+
+  @Test
+  void testMultilineStringInternalQuotes() {
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer(
+      "'''\nit's a 'test' with ''two'' quotes\nend'''"
+    );
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    assertEquals(ApexLexer.MultilineStringLiteral, tokens.get(0).getType());
+  }
+
+  @Test
+  void testMultilineStringEscapeSequences() {
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer(
+      "'''\nescaped: \\'\\'\\'\nend'''"
+    );
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    assertEquals(ApexLexer.MultilineStringLiteral, tokens.get(0).getType());
+  }
+
+  @Test
+  void testMultilineStringLineTracking() {
+    // Token after a 3-line literal should report line 4.
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer(
+      "'''\nhello\nworld\n''' x"
+    );
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    Token last = tokens.get(tokens.size() - 2); // skip EOF
+    assertEquals("x", last.getText());
+    assertEquals(4, last.getLine());
+  }
+
+  @Test
+  void testMultilineStringFallbackWhenNewlineMissing() {
+    // ''' without a following newline must NOT be lexed as a multi-line literal.
+    // ANTLR falls back to legacy: '' 'abc' ''. apex-ls relies on this pattern
+    // (apex-ls#443) to surface a targeted "did you mean a multi-line string?" diagnostic.
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer("'''abc'''");
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    assertEquals(4, tokens.size()); // '', 'abc', '', EOF
+    assertEquals(ApexLexer.StringLiteral, tokens.get(0).getType());
+    assertEquals("''", tokens.get(0).getText());
+    assertEquals(ApexLexer.StringLiteral, tokens.get(1).getType());
+    assertEquals("'abc'", tokens.get(1).getText());
+    assertEquals(ApexLexer.StringLiteral, tokens.get(2).getType());
+    assertEquals("''", tokens.get(2).getText());
+  }
+
+  @Test
+  void testMultilineStringSixQuoteFallback() {
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer("''''''");
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertEquals(0, lc.getValue().getNumErrors());
+    assertEquals(4, tokens.size()); // '', '', '', EOF
+    assertEquals(ApexLexer.StringLiteral, tokens.get(0).getType());
+    assertEquals(ApexLexer.StringLiteral, tokens.get(1).getType());
+    assertEquals(ApexLexer.StringLiteral, tokens.get(2).getType());
+  }
+
+  @Test
+  void testMultilineStringUnterminated() {
+    Map.Entry<ApexLexer, SyntaxErrorCounter> lc = createLexer(
+      "'''\nnever closed"
+    );
+    CommonTokenStream tokens = new CommonTokenStream(lc.getKey());
+    tokens.fill();
+    assertTrue(lc.getValue().getNumErrors() > 0);
+  }
 }

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/ApexParserTest.java
@@ -230,10 +230,10 @@ public class ApexParserTest {
   void testWhenQualifiedEnumValue() {
     Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
       "switch on (x) { \n" +
-      "  when MyEnum.A { return 1; } \n" +
-      "  when MyClass.MyEnum.B { return 2; } \n" +
-      "  when MyEnum.C, MyEnum.D { return 3; } \n" +
-      "}"
+        "  when MyEnum.A { return 1; } \n" +
+        "  when MyClass.MyEnum.B { return 2; } \n" +
+        "  when MyEnum.C, MyEnum.D { return 3; } \n" +
+        "}"
     );
     ApexParser.StatementContext context = parserAndCounter.getKey().statement();
     assertNotNull(context);
@@ -304,5 +304,46 @@ public class ApexParserTest {
       .compilationUnit();
     assertNotNull(context);
     assertEquals(3, parserAndCounter.getValue().getNumErrors());
+  }
+
+  // Salesforce Summer '26 multi-line string literals.
+
+  @Test
+  void testMultilineStringLiteral() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "'''\nhello\nworld\n'''"
+    );
+    ApexParser.LiteralContext context = parserAndCounter.getKey().literal();
+    assertNotNull(context);
+    assertNotNull(context.MultilineStringLiteral());
+    assertEquals(
+      "'''\nhello\nworld\n'''",
+      context.MultilineStringLiteral().getText()
+    );
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
+  void testMultilineStringInClassBody() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "public class Hello { String s = '''\n{\n  \"name\": \"John\"\n}'''; }"
+    );
+    ApexParser.CompilationUnitContext context = parserAndCounter
+      .getKey()
+      .compilationUnit();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
+  void testMultilineStringInConcatenation() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "public class Hello {{ String s = '''\nab''' + ' middle ' + '''\ncd'''; }}"
+    );
+    ApexParser.CompilationUnitContext context = parserAndCounter
+      .getKey()
+      .compilationUnit();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
   }
 }

--- a/npm/test/ApexLexerTest.ts
+++ b/npm/test/ApexLexerTest.ts
@@ -166,3 +166,10 @@ test("Multi-line string: unterminated literal produces a lexer error", () => {
   const { errors } = lex("'''\nnever closed");
   expect(errors).toBeGreaterThan(0);
 });
+
+test("Multi-line string: invalid backslash escape produces a lexer error", () => {
+  // Apex platform rejects '\q' in both single- and triple-quoted strings.
+  // A bare backslash in the body must form a valid EscapeSequence.
+  const { errors } = lex("'''\ninvalid \\q here\n'''");
+  expect(errors).toBeGreaterThan(0);
+});

--- a/npm/test/ApexLexerTest.ts
+++ b/npm/test/ApexLexerTest.ts
@@ -80,3 +80,89 @@ test("Lexer error is captured via createLexerAndParser", () => {
   parser.compilationUnit();
   expect(errorCounter.getNumErrors()).toBeGreaterThan(0);
 });
+
+// Salesforce Summer '26 multi-line string literals: '''<NL>...'''
+// Body must start on a new line after the opening triple quote.
+
+function lex(input: string): { tokens: CommonTokenStream; errors: number } {
+  const [lexer, errorCounter] = createLexer(input);
+  const tokens = new CommonTokenStream(lexer);
+  tokens.fill();
+  return { tokens, errors: errorCounter.getNumErrors() };
+}
+
+test("Multi-line string: basic body, closing on same line", () => {
+  const { tokens, errors } = lex("'''\nhello\nworld'''");
+  expect(errors).toEqual(0);
+  // 1 MultilineStringLiteral + EOF
+  expect((tokens as ExtCommonTokenStream).getNumberOfOnChannelTokens()).toBe(2);
+  expect(tokens.tokens[0].type).toBe(ApexLexer.MultilineStringLiteral);
+});
+
+test("Multi-line string: closing on its own line", () => {
+  const { tokens, errors } = lex("'''\nhello\n'''");
+  expect(errors).toEqual(0);
+  expect(tokens.tokens[0].type).toBe(ApexLexer.MultilineStringLiteral);
+});
+
+test("Multi-line string: empty body", () => {
+  const { tokens, errors } = lex("'''\n'''");
+  expect(errors).toEqual(0);
+  expect(tokens.tokens[0].type).toBe(ApexLexer.MultilineStringLiteral);
+});
+
+test("Multi-line string: single and paired quotes inside body are allowed", () => {
+  const { tokens, errors } = lex(
+    "'''\nit's a 'test' with ''two'' quotes\nend'''"
+  );
+  expect(errors).toEqual(0);
+  expect(tokens.tokens[0].type).toBe(ApexLexer.MultilineStringLiteral);
+});
+
+test("Multi-line string: escape sequences are honoured", () => {
+  // \\'\\'\\' would terminate; \' \' \' should be three escaped quotes.
+  const { tokens, errors } = lex("'''\nescaped: \\'\\'\\'\nend'''");
+  expect(errors).toEqual(0);
+  expect(tokens.tokens[0].type).toBe(ApexLexer.MultilineStringLiteral);
+});
+
+test("Multi-line string: line/column tracking continues after the literal", () => {
+  // Token after a 3-line literal should report line 4.
+  const { tokens, errors } = lex("'''\nhello\nworld\n''' x");
+  expect(errors).toEqual(0);
+  const last = tokens.tokens[tokens.tokens.length - 2]; // skip EOF
+  expect(last.text).toBe("x");
+  expect(last.line).toBe(4);
+});
+
+test("Multi-line string: fallback when newline missing — '''abc''' lexes as 3 string literals", () => {
+  // ''' without a following newline must NOT be lexed as a multi-line literal.
+  // ANTLR falls back to legacy: '' 'abc' ''. apex-ls relies on this pattern
+  // (apex-ls#443) to surface a targeted "did you mean a multi-line string?" diagnostic.
+  const { tokens, errors } = lex("'''abc'''");
+  expect(errors).toEqual(0);
+  expect(tokens.tokens.length).toBe(4); // '', 'abc', '', EOF
+  expect(tokens.tokens[0].type).toBe(ApexLexer.StringLiteral);
+  expect(tokens.tokens[0].text).toBe("''");
+  expect(tokens.tokens[1].type).toBe(ApexLexer.StringLiteral);
+  expect(tokens.tokens[1].text).toBe("'abc'");
+  expect(tokens.tokens[2].type).toBe(ApexLexer.StringLiteral);
+  expect(tokens.tokens[2].text).toBe("''");
+});
+
+test("Multi-line string: six-quote sequence falls back to three empty string literals", () => {
+  const { tokens, errors } = lex("''''''");
+  expect(errors).toEqual(0);
+  expect(tokens.tokens.length).toBe(4); // '', '', '', EOF
+  expect(tokens.tokens[0].type).toBe(ApexLexer.StringLiteral);
+  expect(tokens.tokens[0].text).toBe("''");
+  expect(tokens.tokens[1].type).toBe(ApexLexer.StringLiteral);
+  expect(tokens.tokens[1].text).toBe("''");
+  expect(tokens.tokens[2].type).toBe(ApexLexer.StringLiteral);
+  expect(tokens.tokens[2].text).toBe("''");
+});
+
+test("Multi-line string: unterminated literal produces a lexer error", () => {
+  const { errors } = lex("'''\nnever closed");
+  expect(errors).toBeGreaterThan(0);
+});

--- a/npm/test/ApexParserTest.ts
+++ b/npm/test/ApexParserTest.ts
@@ -285,3 +285,39 @@ test("testDoWhileWithoutBlockFails", () => {
   expect(context).toBeInstanceOf(CompilationUnitContext);
   expect(errorCounter.getNumErrors()).toEqual(3);
 });
+
+// Salesforce Summer '26 multi-line string literals.
+
+test("Multiline String Literal", () => {
+  const [parser, errorCounter] = createParser("'''\nhello\nworld\n'''");
+  const context = parser.literal();
+
+  expect(errorCounter.getNumErrors()).toEqual(0);
+  expect(context).toBeInstanceOf(LiteralContext);
+  expect(context.MultilineStringLiteral()).toBeTruthy();
+  expect(context.MultilineStringLiteral().getText()).toBe(
+    "'''\nhello\nworld\n'''"
+  );
+});
+
+test("Multiline String Literal in class body", () => {
+  const [parser, errorCounter] = createParser(
+    "public class Hello { String s = '''\n{\n  \"name\": \"John\"\n}'''; }"
+  );
+
+  const context = parser.compilationUnit();
+
+  expect(context).toBeInstanceOf(CompilationUnitContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("Multiline String Literal in concatenation", () => {
+  const [parser, errorCounter] = createParser(
+    "public class Hello {{ String s = '''\nab''' + ' middle ' + '''\ncd'''; }}"
+  );
+
+  const context = parser.compilationUnit();
+
+  expect(context).toBeInstanceOf(CompilationUnitContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});


### PR DESCRIPTION
## Summary

Adds `MultilineStringLiteral` token support for Salesforce Summer '26 triple-quoted string syntax (`'''<NL>...'''`). Closes #102.

```apex
String json = '''
{
  "name": "John"
}''';
```

## Empirical findings (verified against Summer '26 pre-release org)

| Input | Platform behaviour |
|---|---|
| `'''abc'''` (no newline after open) | Compile error: "Unexpected symbol 'a', was expecting '\n'" |
| `''''''` (six quotes) | Compile error: same |
| `'''<NL>'''` (empty body) | Valid, produces `""` |
| `'''<NL>...<NL>'''` | Valid; leading newline stripped at runtime |
| Single `'` and double `''` in body | Allowed |
| `\t` `\'` `\\` `ç` escapes | Processed identically to regular strings |
| Indented body + indented closing `'''` | Common leading whitespace stripped at runtime (Java text block semantics) |
| String templates `${var}` + `.template(map)` | `${...}` is plain literal text in the parser; no parser work needed |

Indent stripping is a *runtime* string semantic, not a lexer concern — the token captures raw multi-line text and downstream consumers can resolve as needed.

## Design: strict newline enforcement

The lexer rule requires `[\r\n]` immediately after the opening `'''`:

```antlr
MultilineStringLiteral
    :   '\'\'\'' [\r\n] ( EscapeSequence | . )*? '\'\'\''
    ;
```

This is deliberately strict to match platform behaviour. The alternative — a permissive lexer accepting `'''abc'''` — would silently lex it as a single multi-line literal that the parser accepts but the platform later rejects, hiding the user's mistake.

With strict enforcement, ANTLR falls back gracefully on malformed input: `'''abc'''` lexes as three legacy `StringLiteral` tokens (`''`, `'abc'`, `''`). That's a recognisable, unambiguous token pattern — apex-ls#443 will detect it and surface a targeted "did you mean a multi-line string?" diagnostic with quick fix.

apex-parser stays minimal: just the grammar, no special-case diagnostics. The helpful UX is layered in the language server where it has user context.

## Parser integration

`MultilineStringLiteral` is accepted alongside `StringLiteral` at all 9 sites via inline alternation:
- `literal`, `whenLiteral` (Apex)
- SOQL `value`, `DISTANCE(...)`
- SOSL `WITH DIVISION`, `WITH NETWORK`, `WITH PRICEBOOKID`, `WITH METADATA`, `networkList`

This preserves parse-tree shape — no rule restructure, no breaking change for tree-walking consumers.

## Test plan

- [x] npm tests: 88/88 pass (76 existing + 12 new)
- [x] JVM tests: 87/87 pass (75 existing + 12 new)
- [x] Lint clean
- [x] Lexer tests: basic, closing variants, empty body, internal quotes, escape sequences, line/column tracking after literal, fallback for `'''abc'''`, six-quote fallback, unterminated literal
- [x] Parser tests: `literal` rule, in class body (JSON example), in concatenation expression
- [x] Verified against Summer '26 pre-release org via `sf apex run`

## Follow-up

- apex-ls#443 — Diagnostic & quick fix for malformed multi-line attempts