### PR TITLE
fix: use dynamic import() in npm check script for ESM compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support multi-line string literals (Salesforce Summer '26), e.g. `String json = '''<NL>{...}<NL>''';`
   - New `MultilineStringLiteral` token, accepted alongside `StringLiteral` in literal/SOQL/SOSL contexts.
   - Body must start on a new line after the opening `'''`, matching platform behaviour. Malformed forms like `'''abc'''` continue to lex as legacy `StringLiteral` tokens (`''`, `'abc'`, `''`); apex-ls consumes this pattern to surface a targeted diagnostic (apex-ls#443).
+- Fix `npm run check` failing with `ERR_REQUIRE_ESM` on Node 20+ by switching the script from `require()` to dynamic `import()` (the package is `"type": "module"`).
 
 ## 5.0.0 - 2026-04-21
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -17,7 +17,7 @@
     "antlr": "mvn exec:exec",
     "build": "npm run clean && npm run antlr && tsc",
     "build:test": "npm run build && npm test",
-    "check": "node -e 'require(\"./dist/src/index.js\").check()'",
+    "check": "node -e 'import(\"./dist/src/index.js\").then(m => m.check())'",
     "clean": "rm -rf dist",
     "init": "npm ci && npm run antlr",
     "lint": "eslint --cache --cache-location .eslintcache ./src --fix",


### PR DESCRIPTION
## Summary
- Closes #105
- `npm/package.json` declares `"type": "module"`, so Node 20+ rejected the `require()` call in the `check` script with `ERR_REQUIRE_ESM`. Switched to dynamic `import()` which works in both CJS and ESM contexts.
- Same one-line fix applied in apex-dev-tools/vf-parser@af98f97.

## Test plan
- [x] `npm run check` runs successfully (parses 0 .cls/.trigger/.apex files in the npm dir, as expected)
- [ ] CI passes