### PR TITLE
feat: add SOQL FORMULA() function support

### DIFF
--- a/antlr/BaseApexLexer.g4
+++ b/antlr/BaseApexLexer.g4
@@ -169,6 +169,7 @@ DISTANCE        : 'distance';
 GEOLOCATION     : 'geolocation';
 GROUPING        : 'grouping';
 CONVERT_CURRENCY : 'convertcurrency'; // used in both SOQL and SOSL
+FORMULA          : 'formula';
 
 // SOQL Date functions
 CALENDAR_MONTH      : 'calendar_month';

--- a/antlr/BaseApexParser.g4
+++ b/antlr/BaseApexParser.g4
@@ -706,7 +706,8 @@ conditionalExpression
 
 fieldExpression
     : fieldName comparisonOperator value
-    | soqlFunction comparisonOperator value;
+    | soqlFunction comparisonOperator value
+    | FORMULA LPAREN StringLiteral RPAREN comparisonOperator value;
 
 comparisonOperator
     : ASSIGN | NOTEQUAL | LT | GT | LT ASSIGN | GT ASSIGN | LESSANDGREATER | LIKE | IN | NOT IN | INCLUDES | EXCLUDES;
@@ -1002,6 +1003,7 @@ id
     | DISTANCE
     | GEOLOCATION
     | GROUPING
+    | FORMULA
     | CONVERT_CURRENCY
     // SOQL date functions
     | CALENDAR_MONTH
@@ -1202,6 +1204,7 @@ anyId
     | DISTANCE
     | GEOLOCATION
     | GROUPING
+    | FORMULA
     | CONVERT_CURRENCY
     // SOQL date functions
     | CALENDAR_MONTH

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
@@ -220,4 +220,34 @@ public class SOQLParserTest {
     assertNotNull(context);
     assertEquals(0, parserAndCounter.getValue().getNumErrors());
   }
+
+  @Test
+  void testFormulaFunction() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "SELECT Id FROM Account WHERE FORMULA('EndDate - StartDate') > 10"
+    );
+    ApexParser.QueryContext context = parserAndCounter.getKey().query();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
+  void testFormulaFunctionWithStringComparison() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "SELECT Id FROM Account WHERE FORMULA('TRIM(name, 4)') = 'Acme'"
+    );
+    ApexParser.QueryContext context = parserAndCounter.getKey().query();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
+  void testFormulaFunctionWithEscapedQuotes() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "SELECT Id FROM Contact WHERE FORMULA('FirstName & \" O\\'Brian\"') = 'Colleen O\\'Brian'"
+    );
+    ApexParser.QueryContext context = parserAndCounter.getKey().query();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
 }

--- a/npm/test/SOQLParserTest.ts
+++ b/npm/test/SOQLParserTest.ts
@@ -211,3 +211,36 @@ test("rollupWithSoqlFunction", () => {
   expect(context).toBeInstanceOf(SoqlLiteralContext);
   expect(errorCounter.getNumErrors()).toEqual(0);
 });
+
+test("testFormulaFunction", () => {
+  const [parser, errorCounter] = createParser(
+    "SELECT Id FROM Account WHERE FORMULA('EndDate - StartDate') > 10"
+  );
+
+  const context = parser.query();
+
+  expect(context).toBeInstanceOf(QueryContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("testFormulaFunctionWithStringComparison", () => {
+  const [parser, errorCounter] = createParser(
+    "SELECT Id FROM Account WHERE FORMULA('TRIM(name, 4)') = 'Acme'"
+  );
+
+  const context = parser.query();
+
+  expect(context).toBeInstanceOf(QueryContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("testFormulaFunctionWithEscapedQuotes", () => {
+  const [parser, errorCounter] = createParser(
+    "SELECT Id FROM Contact WHERE FORMULA('FirstName & \" O\\'Brian\"') = 'Colleen O\\'Brian'"
+  );
+
+  const context = parser.query();
+
+  expect(context).toBeInstanceOf(QueryContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});


### PR DESCRIPTION
## Summary
- Add `FORMULA` token to the lexer and parser grammars
- Support `FORMULA('expression')` syntax in SOQL WHERE clause field expressions
- Add tests for formula function parsing in both JVM and npm packages

## Test plan
- [x] npm tests pass (92 tests, 8 suites)
- [x] JVM tests pass (91 tests, 0 failures)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)