### PR TITLE
chore: prep 5.1.0-beta.1 release and tag prereleases as 'beta' on npm

### DIFF
--- a/.github/workflows/PublishNPM.yml
+++ b/.github/workflows/PublishNPM.yml
@@ -22,6 +22,13 @@ jobs:
           npm run init:npm
           npm run build:npm
           cd npm
-          npm publish --access public
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            echo "Publishing $VERSION under dist-tag 'beta'"
+            npm publish --access public --tag beta
+          else
+            echo "Publishing $VERSION under dist-tag 'latest'"
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>apex-parser</artifactId>
-  <version>5.1.0-SNAPSHOT</version>
+  <version>5.1.0-beta.1</version>
   <packaging>jar</packaging>
 
   <name>apex-parser</name>


### PR DESCRIPTION
## Summary

- Bumps `jvm/pom.xml` from `5.1.0-SNAPSHOT` to `5.1.0-beta.1` so the Maven artifact version matches `npm/package.json` for the upcoming beta release.
- Updates `PublishNPM.yml` to detect pre-release versions (semver hyphen) and publish them under the `beta` dist-tag. Final releases continue to publish as `latest`.

## Why

The v5.0.0-beta.5 publish landed as `latest` on npm because the workflow always ran `npm publish --access public` with no `--tag`. With this change, any version containing a `-` (e.g. `5.1.0-beta.1`, `5.2.0-rc.1`) publishes as `@beta`, leaving `latest` pointing at the most recent stable release.

## Test plan

- [ ] CI (`Build` workflow) passes — pom version bump and a workflow file edit shouldn't affect build/test outputs.
- [ ] After merge, tag `v5.1.0-beta.1`, create a GitHub pre-release, then manually dispatch `Publish to NPM` and `Publish to Maven`.
- [ ] Verify `npm view @apexdevtools/apex-parser dist-tags` shows `latest` unchanged and `beta` set to `5.1.0-beta.1`.
- [ ] Verify Maven Central lists `io.github.apex-dev-tools:apex-parser:5.1.0-beta.1`.