### PR TITLE
chore: release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 # apex-parser - Changelog
 
-## Unreleased
-
-- Restrict SOQL `FORMULA()` expressions to `WHERE` clauses; `HAVING FORMULA(...)` now reports a syntax error.
-
-## 5.1.0-beta.1
+## 5.1.0 - 2026-07-03
 
 - Allow functions in `GROUP BY` clause of SOQL queries
 - Support Apex bind variables (`:expr`) in SOSL `WITH DIVISION` clause
@@ -13,6 +9,7 @@
 - Support multi-line string literals (Salesforce Summer '26), e.g. `String json = '''<NL>{...}<NL>''';`
   - New `MultilineStringLiteral` token, accepted alongside `StringLiteral` in literal/SOQL/SOSL contexts.
   - Body must start on a new line after the opening `'''`, matching platform behaviour. Malformed forms like `'''abc'''` continue to lex as legacy `StringLiteral` tokens (`''`, `'abc'`, `''`); apex-ls consumes this pattern to surface a targeted diagnostic (apex-ls#443).
+- Support the SOQL `FORMULA()` function in `WHERE` clauses, e.g. `WHERE FORMULA('...') = true`; use in any other clause (e.g. `HAVING FORMULA(...)`) reports a syntax error.
 - Fix `npm run check` failing with `ERR_REQUIRE_ESM` on Node 20+ by switching the script from `require()` to dynamic `import()` (the package is `"type": "module"`).
 - Update npm package build output to publish separate ESM, CommonJS, browser, and TypeScript declaration artifacts through the package `exports` map.
 

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>apex-parser</artifactId>
-  <version>5.1.0-beta.1</version>
+  <version>5.1.0</version>
   <packaging>jar</packaging>
 
   <name>apex-parser</name>

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "5.1.0-beta.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/apex-parser",
-      "version": "5.1.0-beta.1",
+      "version": "5.1.0",
       "bundleDependencies": [
         "antlr4"
       ],

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "5.1.0-beta.1",
+  "version": "5.1.0",
   "description": "Javascript parser for Salesforce Apex Language",
   "author": "Apex Dev Tools Team <apexdevtools@gmail.com> (https://github.com/apex-dev-tools)",
   "bugs": "https://github.com/apex-dev-tools/apex-parser/issues",


### PR DESCRIPTION
Release prep for **v5.1.0**. Closes #128.

## Changes
- **CHANGELOG**: collapse `Unreleased` + `5.1.0-beta.1` into a single dated `## 5.1.0 - 2026-07-03` section. The SOQL `FORMULA()` feature is now recorded as a feature (support in `WHERE`; syntax error elsewhere) rather than only its restriction, since the feature itself landed after `5.1.0-beta.1`.
- **Version bump** `5.1.0-beta.1 → 5.1.0` in `jvm/pom.xml`, `npm/package.json`, `npm/package-lock.json`.

## Validation (matches CI Build.yml)
- `npm run init` → ANTLR generation OK, `Building apex-parser 5.1.0`
- `npm run build` → JVM surefire **92 passed**, jest **93 passed**
- `npm run systest` (apex-samples `v1.4.0`) → **100 snapshots passed**

## Release gate
apex-ls #441 (upgrade apex-parser to 5.1.0) and #443 (multiline-string diagnostic) are both CLOSED/COMPLETED — downstream validation done.

## After merge
Create GitHub Release `v5.1.0` (non-prerelease) to trigger `PublishMaven.yml` + `PublishNPM.yml` (publishes to Maven Central + npm `latest`). Then a follow-up commit on `main` to bump to the next dev version and record the release date.