### PR TITLE
Build and publish with JDK 17

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 11
+          java-version: 17
           cache: "maven"
 
       - name: Init

--- a/.github/workflows/PublishMaven.yml
+++ b/.github/workflows/PublishMaven.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: "temurin"
           cache: "maven"
           server-id: central


### PR DESCRIPTION
## Summary
- build and publish with Temurin JDK 17 in CI
- retain Maven `<release>8</release>` bytecode/API targeting

## Verification
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home npm run init && npm run build`
- npm: 8 suites / 93 tests passed
- JVM: 92 tests passed
- verified a compiled class with `javap -v`: major version 52 (Java 8)
