### PR TITLE
Fix dataCategoryName: close parenthesized data category list with RPAREN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # apex-parser - Changelog
 
+## Unreleased
+
+- Fix the `dataCategoryName` grammar rule so parenthesized SOQL data category lists close with `RPAREN`; previously, valid multi-category `WITH DATA CATEGORY` filters failed to parse.
+
 ## 5.1.0 - 2026-07-03
 
 - Allow functions in `GROUP BY` clause of SOQL queries

--- a/antlr/BaseApexParser.g4
+++ b/antlr/BaseApexParser.g4
@@ -762,7 +762,7 @@ dataCategorySelection
 
 dataCategoryName
     : soqlId
-    | LPAREN soqlId (COMMA soqlId)* LPAREN;
+    | LPAREN soqlId (COMMA soqlId)* RPAREN;
 
 filteringSelector
     : AT | ABOVE | BELOW | ABOVE_OR_BELOW;

--- a/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
+++ b/jvm/src/test/java/io/github/apexdevtools/apexparser/SOQLParserTest.java
@@ -44,6 +44,36 @@ public class SOQLParserTest {
   }
 
   @Test
+  void testSOQLWhereWithSingleDataCategoryFilter() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "SELECT Title FROM KnowledgeArticleVersion WHERE PublishStatus='online' WITH DATA CATEGORY Geography__c ABOVE usa__c"
+    );
+    ApexParser.QueryContext context = parserAndCounter.getKey().query();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
+  void testSOQLWhereWithDataCategoryListFilter() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "SELECT Title FROM Question WHERE LastReplyDate > 2005-10-08T01:02:03Z WITH DATA CATEGORY Geography__c AT (usa__c, uk__c)"
+    );
+    ApexParser.QueryContext context = parserAndCounter.getKey().query();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
+  void testSOQLWhereWithMultipleDataCategoryFilters() {
+    Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+      "SELECT UrlName FROM KnowledgeArticleVersion WHERE PublishStatus='draft' WITH DATA CATEGORY Geography__c AT usa__c AND Product__c ABOVE_OR_BELOW mobile_phones__c"
+    );
+    ApexParser.QueryContext context = parserAndCounter.getKey().query();
+    assertNotNull(context);
+    assertEquals(0, parserAndCounter.getValue().getNumErrors());
+  }
+
+  @Test
   void testCurrencyLiteral() {
     Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
       "SELECT Id FROM Account WHERE Amount > USD100.01 AND Amount < USD200"

--- a/npm/test/SOQLParserTest.ts
+++ b/npm/test/SOQLParserTest.ts
@@ -26,6 +26,36 @@ test("SOQL Query", () => {
   expect(errorCounter.getNumErrors()).toEqual(0);
 });
 
+test("SOQL Where with single data category filter", () => {
+  const [parser, errorCounter] = createParser(
+    "SELECT Title FROM KnowledgeArticleVersion WHERE PublishStatus='online' WITH DATA CATEGORY Geography__c ABOVE usa__c"
+  );
+  const context = parser.query();
+
+  expect(context).toBeInstanceOf(QueryContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("SOQL Where with data category list filter", () => {
+  const [parser, errorCounter] = createParser(
+    "SELECT Title FROM Question WHERE LastReplyDate > 2005-10-08T01:02:03Z WITH DATA CATEGORY Geography__c AT (usa__c, uk__c)"
+  );
+  const context = parser.query();
+
+  expect(context).toBeInstanceOf(QueryContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
+test("SOQL Where with multiple data category filters", () => {
+  const [parser, errorCounter] = createParser(
+    "SELECT UrlName FROM KnowledgeArticleVersion WHERE PublishStatus='draft' WITH DATA CATEGORY Geography__c AT usa__c AND Product__c ABOVE_OR_BELOW mobile_phones__c"
+  );
+  const context = parser.query();
+
+  expect(context).toBeInstanceOf(QueryContext);
+  expect(errorCounter.getNumErrors()).toEqual(0);
+});
+
 test("SOQL Query Using Field function", () => {
   const [parser, errorCounter] = createParser(
     "Select Fields(All) from Account"


### PR DESCRIPTION
Fixes #141

## Change

One token in `antlr/BaseApexParser.g4`: the second alternative of `dataCategoryName` closed the parenthesized list with `LPAREN` instead of `RPAREN`, so valid multi-category `WITH DATA CATEGORY` filters failed to parse.

```diff
 dataCategoryName
     : soqlId
-    | LPAREN soqlId (COMMA soqlId)* LPAREN;
+    | LPAREN soqlId (COMMA soqlId)* RPAREN;
```

## Tests

Added three regression tests to `SOQLParserTest` in both the npm and jvm targets, using the example queries verbatim from the [Salesforce WITH DATA CATEGORY documentation](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_with_datacategory.htm): single category (`ABOVE usa__c`), parenthesized list (`AT (usa__c, uk__c)`), and AND-joined selections.

Verified fail-first: with the unmodified grammar, the parenthesized-list test fails with exactly one syntax error at the closing `)`; the other tests pass. With the fix: npm suite 96/96 (8 suites), jvm 94/94 via `mvn package` (SOQLParserTest 23/23).

Also added a `## Unreleased` CHANGELOG entry following the convention from #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)