### PR TITLE
chore: release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # apex-parser - Changelog
 
-## Unreleased
+## 5.2.0 - 2026-08-21
 
 - Tighten the annotation grammar to reject constructs that are inherited from Java but are not legal Apex
+  - **(SOURCE BREAKING)** `ElementValueArrayInitializerContext` is no longer generated, `AnnotationContext.qualifiedName()` becomes `id()`, and `ElementValueContext` exposes only `literal()`. Tree-walking consumers referencing these need updating. This ships as a minor version, not a major one; grammar changes of this kind are routine here and major bumps are reserved for build-environment or large-scale changes
   - `annotation` matches `id` in place of `qualifiedName`; `@Schema.AuraEnabled` is now a syntax error, matching the platform (`Unexpected token '.'`). Apex has no user-defined annotations, so a namespace-qualified form has never been legal
   - `elementValue` matches `literal` in place of `expression`, so a bare identifier value such as `@AuraEnabled(cacheable=foo)` is now a syntax error, as it is on the platform
   - Nested annotations and array initialiser values (`label={'a','b'}`) are no longer accepted, and the `elementValueArrayInitializer` rule is removed. `elementValue` is now non-recursive
-  - **(SOURCE BREAKING)** `ElementValueArrayInitializerContext` is no longer generated, `AnnotationContext.qualifiedName()` becomes `id()`, and `ElementValueContext` exposes only `literal()`. Tree-walking consumers referencing these need updating. This ships as a minor version, not a major one; grammar changes of this kind are routine here and major bumps are reserved for build-environment or large-scale changes
   - The optional `COMMA` separator between annotation parameters is deliberately kept, and is now documented in the grammar as the one exception. The platform separates parameters by whitespace alone, but rejecting the comma form at parse time reproduces the platform compiler's own failure mode, where a member-level annotation is recovered as a constructor declaration and the rest of the file is lost to cascading errors
   - Values the platform rejects for type reasons, such as `@AuraEnabled(cacheable=0)` and `cacheable=null`, still parse. That is intended, so a consumer can diagnose the value precisely instead of losing the file to a syntax error
-  - Adds annotation parameter test coverage to both the maven and npm targets
+  - Add annotation parameter test coverage to both the maven and npm targets
 - Add [`doc/SalesforceDifferences.md`](doc/SalesforceDifferences.md), recording deliberate differences between what this grammar accepts and what the Salesforce platform compiler accepts, so they are not mistakenly "corrected" later. The first entry is the annotation parameter comma separator above
-- Fix the `dataCategoryName` grammar rule so parenthesized SOQL data category lists close with `RPAREN`; previously, valid multi-category `WITH DATA CATEGORY` filters failed to parse.
 - Support the SOSL `WITH SPELL_CORRECTION = { true | false }` clause, e.g. `[FIND :term IN ALL FIELDS RETURNING Account WITH SPELL_CORRECTION = false]`; an Apex bind variable (`:expr`) is also accepted in place of the literal
 - Support the SOSL `WITH HIGHLIGHT` clause, e.g. `[FIND 'salesforce' IN ALL FIELDS RETURNING Account(Name, Description) WITH HIGHLIGHT]`
 - New `HIGHLIGHT` and `SPELL_CORRECTION` lexer tokens; both are also accepted as identifiers (`id`/`anyId`), so existing code using them as names is unaffected
+- Fix the `dataCategoryName` grammar rule so parenthesized SOQL data category lists close with `RPAREN`; previously, valid multi-category `WITH DATA CATEGORY` filters failed to parse
 - Fix `WITH DATA CATEGORY` filters with more than one selection. `filteringExpression` joined selections with the `AND` token, which is the Java `&&` operator, not the SOQL `and` keyword. In SOSL this was a parse error; in SOQL the trailing selections were silently left unconsumed
 
 ## 5.1.0 - 2026-07-03

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.apex-dev-tools</groupId>
   <artifactId>apex-parser</artifactId>
-  <version>5.1.0</version>
+  <version>5.2.0</version>
   <packaging>jar</packaging>
 
   <name>apex-parser</name>

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apexdevtools/apex-parser",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "bundleDependencies": [
         "antlr4"
       ],

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/apex-parser",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Javascript parser for Salesforce Apex Language",
   "author": "Apex Dev Tools Team <apexdevtools@gmail.com> (https://github.com/apex-dev-tools)",
   "bugs": "https://github.com/apex-dev-tools/apex-parser/issues",


### PR DESCRIPTION
Release prep for **v5.2.0**. Closes #151.

## Changes

- **CHANGELOG**: collapse `Unreleased` into a dated `## 5.2.0 - 2026-08-21` section. All entries kept; edited for a release-notes audience:
  - the **(SOURCE BREAKING)** note is promoted to the first sub-bullet of the annotation item, so the one thing consumers have to act on is the first thing they read under it
  - the two `WITH DATA CATEGORY` fixes are now adjacent, with the section ordered features first, fixes last
  - minor tidy: imperative mood on the test-coverage bullet, trailing full stops made consistent
  - npm dev-dependency bumps are not recorded, matching 5.1.0 and earlier sections
- **Version bump** `5.1.0 → 5.2.0` in `jvm/pom.xml`, `npm/package.json`, `npm/package-lock.json`. Those are the only files carrying the artifact version — the root `package.json` is the private `apex-parser-build` wrapper pinned at `1.0.0`, and no README or doc quotes a version.

Minor, not major: the grammar change is source-breaking for tree-walking consumers, but changes of this kind are routine here and major bumps are reserved for build-environment or large-scale changes.

## Validation (matches CI Build.yml)

Run on JDK 17 / Node 24, exactly the CI sequence:

- `npm run init` → ANTLR generation OK, `Building apex-parser 5.2.0`
- `npm run build` → JVM surefire **139 passed** (0 failures, 0 errors, 0 skipped), jest **140 passed** across 9 suites
- `npm run systest` (apex-samples `v1.4.0`, `1556acf`, 106 submodules) → **100 snapshots passed**, 100 tests, no snapshot drift

## Release gate

Unlike #131, downstream validation **cannot** be done before this release: both in-house consumers build against published artifacts, so neither can compile against 5.2.0 until it exists. The annotation tightening removes generated API, so this is a code change downstream, not just a version bump. Call sites, per #151:

- **apex-ls** — `jvm/src/main/scala/com/nawforce/apexlink/cst/CST.scala`
  - `:131` `QualifiedName.construct(annotation.qualifiedName())` — `AnnotationContext.qualifiedName()` is now `id()`
  - `:142`, `:157`, `:166`–`:171` — the `ElementValueArrayInitializer` CST class and its `construct` are built on `ElementValueArrayInitializerContext`, which is no longer generated. It models a construct that can no longer be parsed, so it should be deleted rather than ported
  - `:124` `annotation.elementValue()` is unaffected
- **outline-parser** — `jvm/src/test/scala/io/github/apexdevtools/oparser/testutil/AntlrParser.scala:87` — `ctx.qualifiedName().id()` on the annotation context, in the ANTLR reference parser used for the sample comparison. Test scope only, but it blocks that build

No downstream fixes are attempted in this PR; the order is release 5.2.0, then bump and fix.

## After merge

1. Create GitHub Release `v5.2.0` (non-prerelease) to trigger `PublishMaven.yml` + `PublishNPM.yml` (Maven Central + npm `latest`). If publishing fails, check the org Maven signing key first — the annual GPG expiry presents as a missing secret, not an expired key.
2. Then downstream, in order: outline-parser bump + reference-parser fix, then apex-ls bump + `CST.scala` cleanup.
